### PR TITLE
[PSCmdAssistant] added the new query param to retrieve the capacity reservation group resource ids that are owned and shared by a subscription in the List Capacity reservation Group API-17

### DIFF
--- a/src/Compute/Compute/ChangeLog.md
+++ b/src/Compute/Compute/ChangeLog.md
@@ -20,6 +20,9 @@
 
 -->
 ## Upcoming Release
+* Added new parameter `ResourceIdsOnly` to `Get-AzCapacityReservationGroup` cmdlet.
+    - The data type for `ResourceIdsOnly` is a string.
+    - Allowed values for `ResourceIdsOnly` are "CreatedInSubscription", "SharedWithSubscription", and "All".
 
 ## Version 7.2.0
 * Added parameters `-scriptUriManagedIdentity`, `-outputBlobManagedIdentity`, `-errorBlobMangedIdentity`, and `-TreatFailureAsDeploymentFailure` to cmdlets `Set-AzVmRunCommand` and `Set-AzVmssRunCommand`. 

--- a/src/Compute/Compute/Generated/CapacityReservation/GetAzCapacityReservationGroupCommand.cs
+++ b/src/Compute/Compute/Generated/CapacityReservation/GetAzCapacityReservationGroupCommand.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) Microsoft and contributors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -67,6 +67,12 @@ namespace Microsoft.Azure.Commands.Compute.Automation
             ValueFromPipelineByPropertyName = true,
             HelpMessage = "Get the Instance View of the Capacity Reservation Group.")]
         public SwitchParameter InstanceView { get; set; }
+
+        [Parameter(
+            Mandatory = false,
+            HelpMessage = "Get the Resource Ids only.")]
+        [ValidateSet("CreatedInSubscription", "SharedWithSubscription", "All")]
+        public string ResourceIdsOnly { get; set; }
 
         public override void ExecuteCmdlet()
         {
@@ -148,3 +154,4 @@ namespace Microsoft.Azure.Commands.Compute.Automation
         }
     }
 }
+

--- a/src/Compute/Compute/Generated/Models/PSCapacityReservationGroup.cs
+++ b/src/Compute/Compute/Generated/Models/PSCapacityReservationGroup.cs
@@ -1,4 +1,4 @@
-using System;
+ using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Microsoft.Azure.Management.Compute.Models;
@@ -17,5 +17,6 @@ namespace Microsoft.Azure.Commands.Compute.Automation.Models
         public CapacityReservationGroupInstanceView InstanceView { get; set; }
         public IList<string> Zones { get; set; }
         public ResourceSharingProfile SharingProfile { get; set; }
+        public string ResourceIdsOnly { get; set; }
     }
 }


### PR DESCRIPTION
resolves https://github.com/Azure/ps-cmdlet-dev-assistant/issues/17 <br> Error: New Cmdlet not found in issue body