### PR TITLE
[PSCmdAssistant] [Test] Get-AzVmss dont allow empty values for ResourceGroupName and VMScaleSetName-22

### DIFF
--- a/src/Compute/Compute/ChangeLog.md
+++ b/src/Compute/Compute/ChangeLog.md
@@ -19,7 +19,7 @@
         - Additional information about change #1
 
 -->
-## Upcoming Release
+* Updated cmdlet `Get-AzVmss` to throw an error if the parameters `ResourceGroupName` and `VMScaleSetName` are used but are empty. This change is implemented to avoid a bug where the cmdlet would return nothing if these parameters were empty. 
 
 ## Version 7.2.0
 * Added parameters `-scriptUriManagedIdentity`, `-outputBlobManagedIdentity`, `-errorBlobMangedIdentity`, and `-TreatFailureAsDeploymentFailure` to cmdlets `Set-AzVmRunCommand` and `Set-AzVmssRunCommand`. 

--- a/src/Compute/Compute/Generated/VirtualMachineScaleSet/VirtualMachineScaleSetGetMethod.cs
+++ b/src/Compute/Compute/Generated/VirtualMachineScaleSet/VirtualMachineScaleSetGetMethod.cs
@@ -1,4 +1,4 @@
-//
+ //
 // Copyright (c) Microsoft and contributors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,6 +49,11 @@ namespace Microsoft.Azure.Commands.Compute.Automation
             {
                 string resourceGroupName = this.ResourceGroupName;
                 string vmScaleSetName = this.VMScaleSetName;
+
+                if (string.IsNullOrWhiteSpace(resourceGroupName) || string.IsNullOrWhiteSpace(vmScaleSetName))
+                {
+                    throw new ArgumentException("ResourceGroupName and VMScaleSetName cannot be empty");
+                }
 
                 if (ShouldGetByName(resourceGroupName, vmScaleSetName))
                 {
@@ -168,6 +173,7 @@ namespace Microsoft.Azure.Commands.Compute.Automation
             ValueFromPipelineByPropertyName = true)]
         [ResourceGroupCompleter]
         [SupportsWildcards]
+        [ValidateNotNullOrEmpty]
         public string ResourceGroupName { get; set; }
 
         [Parameter(
@@ -185,6 +191,7 @@ namespace Microsoft.Azure.Commands.Compute.Automation
         [ResourceNameCompleter("Microsoft.Compute/virtualMachineScaleSets", "ResourceGroupName")]
         [SupportsWildcards]
         [Alias("Name")]
+        [ValidateNotNullOrEmpty]
         public string VMScaleSetName { get; set; }
 
         [Parameter(
@@ -212,3 +219,4 @@ namespace Microsoft.Azure.Commands.Compute.Automation
         public string ResourceId { get; set; }
     }
 }
+

--- a/src/Compute/Compute/Manual/PSVirtualMachineScaleSet.cs
+++ b/src/Compute/Compute/Manual/PSVirtualMachineScaleSet.cs
@@ -1,4 +1,4 @@
-// 
+ // 
 // Copyright (c) Microsoft and contributors.  All rights reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
resolves https://github.com/Azure/ps-cmdlet-dev-assistant/issues/22 <br> 