### PR TITLE
[PSCmdAssistant] Use Win2022AzureEdition image when seucrityType is explicitly set to Standard-27

### DIFF
--- a/src/Compute/Compute/ChangeLog.md
+++ b/src/Compute/Compute/ChangeLog.md
@@ -19,7 +19,10 @@
         - Additional information about change #1
 
 -->
-## Upcoming Release
+* Added new business logic to `New-AzVmss` cmdlet. When the user explicitly sets the `SecurityType` to `Standard`, the Image alias is set to `Win2022AzureEdition`.
+    - This change affects all parameter sets on the `New-AzVmss` cmdlet.
+    - Link to diff between markdown help files: `{ ENTER LINK HERE }`
+    - Link to API tests for this feature: `{ ENTER LINK HERE }`
 
 ## Version 7.2.0
 * Added parameters `-scriptUriManagedIdentity`, `-outputBlobManagedIdentity`, `-errorBlobMangedIdentity`, and `-TreatFailureAsDeploymentFailure` to cmdlets `Set-AzVmRunCommand` and `Set-AzVmssRunCommand`. 

--- a/src/Compute/Compute/Generated/VirtualMachineScaleSet/VirtualMachineScaleSetCreateOrUpdateMethod.cs
+++ b/src/Compute/Compute/Generated/VirtualMachineScaleSet/VirtualMachineScaleSetCreateOrUpdateMethod.cs
@@ -1,4 +1,4 @@
-//
+None //
 // Copyright (c) Microsoft and contributors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -168,6 +168,17 @@ namespace Microsoft.Azure.Commands.Compute.Automation
                                 {
                                     parameters.VirtualMachineProfile.SecurityProfile.SecurityType = null;
                                 }
+                            }
+
+                            if (parameters.VirtualMachineProfile?.SecurityProfile?.SecurityType?.ToLower() == "standard")
+                            {
+                                parameters.VirtualMachineProfile.StorageProfile.ImageReference = new ImageReference
+                                {
+                                    Publisher = "MicrosoftWindowsServer",
+                                    Offer = "WindowsServer",
+                                    Sku = "2022-Datacenter-Azure-Edition",
+                                    Version = "latest"
+                                };
                             }
 
                             VirtualMachineScaleSet result;
@@ -403,3 +414,4 @@ namespace Microsoft.Azure.Commands.Compute.Automation
         public SwitchParameter EnableAutomaticOSUpgrade{ get; set; }
     }
 }
+

--- a/src/Compute/Compute/Manual/PSVirtualMachineScaleSet.cs
+++ b/src/Compute/Compute/Manual/PSVirtualMachineScaleSet.cs
@@ -1,4 +1,4 @@
-// 
+ // 
 // Copyright (c) Microsoft and contributors.  All rights reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,4 +27,4 @@ namespace Microsoft.Azure.Commands.Compute.Automation.Models
         public string FullyQualifiedDomainName { get; set; }
 
     }
-}
+}None


### PR DESCRIPTION
resolves https://github.com/Azure/ps-cmdlet-dev-assistant/issues/27 <br> 