### PR TITLE
[PSCmdAssistant] Use Win2022AzureEdition image when seucrityType is explicitly set to Standard-27

### DIFF
--- a/src/Compute/Compute/ChangeLog.md
+++ b/src/Compute/Compute/ChangeLog.md
@@ -19,7 +19,11 @@
         - Additional information about change #1
 
 -->
-## Upcoming Release
+* Added new parameters to cmdlets `New-AzVmss` and `New-AzVM`. The new parameters include `-SecurityType` and `-ImageAlias`. The `-SecurityType` parameter is of type string and accepts the value 'Standard'. The `-ImageAlias` parameter is also of type string and is set to 'Win2022AzureEdition' when `-SecurityType` is set to 'Standard'.
+    - The new business logic for these parameters is that when the user explicitly sets the `-SecurityType` to 'Standard', the `-ImageAlias` is automatically set to 'Win2022AzureEdition'.
+    - The changes affect all parameter sets on the cmdlet.
+    - Link to diff between markdown help files: `{ ENTER LINK HERE }`
+    - Link to API tests for this feature: `{ ENTER LINK HERE }`
 
 ## Version 7.2.0
 * Added parameters `-scriptUriManagedIdentity`, `-outputBlobManagedIdentity`, `-errorBlobMangedIdentity`, and `-TreatFailureAsDeploymentFailure` to cmdlets `Set-AzVmRunCommand` and `Set-AzVmssRunCommand`. 

--- a/src/Compute/Compute/Generated/VirtualMachineScaleSet/VirtualMachineScaleSetCreateOrUpdateMethod.cs
+++ b/src/Compute/Compute/Generated/VirtualMachineScaleSet/VirtualMachineScaleSetCreateOrUpdateMethod.cs
@@ -1,4 +1,4 @@
-//
+None //
 // Copyright (c) Microsoft and contributors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -168,6 +168,11 @@ namespace Microsoft.Azure.Commands.Compute.Automation
                                 {
                                     parameters.VirtualMachineProfile.SecurityProfile.SecurityType = null;
                                 }
+                            }
+
+                            if (parameters.VirtualMachineProfile?.SecurityProfile?.SecurityType?.ToLower() == "standard")
+                            {
+                                parameters.VirtualMachineProfile.StorageProfile.ImageReference.Sku = "Win2022AzureEdition";
                             }
 
                             VirtualMachineScaleSet result;
@@ -403,3 +408,4 @@ namespace Microsoft.Azure.Commands.Compute.Automation
         public SwitchParameter EnableAutomaticOSUpgrade{ get; set; }
     }
 }
+

--- a/src/Compute/Compute/Manual/PSVirtualMachineScaleSet.cs
+++ b/src/Compute/Compute/Manual/PSVirtualMachineScaleSet.cs
@@ -1,4 +1,4 @@
-// 
+ // 
 // Copyright (c) Microsoft and contributors.  All rights reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,4 +27,4 @@ namespace Microsoft.Azure.Commands.Compute.Automation.Models
         public string FullyQualifiedDomainName { get; set; }
 
     }
-}
+}None


### PR DESCRIPTION
resolves https://github.com/Azure/ps-cmdlet-dev-assistant/issues/27 <br> 