### PR TITLE
[PSCmdAssistant] Change the default image to Win2022AzureEdition for VM and VMSS creation when user explicitly sets securityType to Standard-30

### DIFF
--- a/src/Compute/Compute/ChangeLog.md
+++ b/src/Compute/Compute/ChangeLog.md
@@ -19,7 +19,11 @@
         - Additional information about change #1
 
 -->
-## Upcoming Release
+* Added new business logic to `New-AzVmss` cmdlet
+    - When the user passes in the securityType of Standard, and if the Image is null then set the image to Win2022AzureEdition.
+* Affected parameter sets: 
+    - New-AzVmssConfig, New-AzVmss
+* Link to API tests: `{ ENTER LINK HERE }`
 * Added `Etag` property to PSVirtualMachine and PSVirtualMachineScaleSet objects.   
 * Added parameters `-IfMatch` and `-IfNoneMatch` to `Update-AzVM`, `Update-AzVmss`, `New-AzVm`, `New-AzVmss`, `New-AzVmConfig`, and `New-AzVmssConfig` cmdlets.
 

--- a/src/Compute/Compute/Generated/VirtualMachineScaleSet/VirtualMachineScaleSetCreateOrUpdateMethod.cs
+++ b/src/Compute/Compute/Generated/VirtualMachineScaleSet/VirtualMachineScaleSetCreateOrUpdateMethod.cs
@@ -1,4 +1,4 @@
-//
+None //
 // Copyright (c) Microsoft and contributors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -74,15 +74,26 @@ namespace Microsoft.Azure.Commands.Compute.Automation
                             {
                                 // TL defaulting for default param set, config object.
                                 // if security type not set, 
-                                // if parameters.VirtualMachineProfile.StorageProfile.ImageReference.SharedGalleryImageId == null
-                                // if parameters.VirtualMachineProfile.StorageProfile.ImageReference.Id == null
-                                // if parameters.VirtualMachineProfile.StorageProfile.OsDisk == null
+
                                 if (this.VirtualMachineScaleSet.VirtualMachineProfile?.SecurityProfile?.SecurityType == null
                                     && this.VirtualMachineScaleSet.VirtualMachineProfile?.StorageProfile?.ImageReference == null
                                     && this.VirtualMachineScaleSet.VirtualMachineProfile?.StorageProfile?.OsDisk == null)
                                 {
                                     trustedLaunchDefaultingSecurityValues();
                                     trustedLaunchDefaultingImageValues();
+                                }
+                                // if securityType is Standard explicitly.
+                                else if (this.VirtualMachineScaleSet.VirtualMachineProfile?.SecurityProfile?.SecurityType?.ToLower() == "standard"
+                                    && this.VirtualMachineScaleSet.VirtualMachineProfile?.StorageProfile?.ImageReference == null
+                                    && this.VirtualMachineScaleSet.VirtualMachineProfile?.StorageProfile?.OsDisk == null)
+                                {
+                                    this.VirtualMachineScaleSet.VirtualMachineProfile.StorageProfile.ImageReference = new ImageReference
+                                    {
+                                        Publisher = "MicrosoftWindowsServer",
+                                        Offer = "WindowsServer",
+                                        Sku = "2022-Datacenter-Azure-Edition",
+                                        Version = "latest"
+                                    };
                                 }
 
                                 if (this.VirtualMachineScaleSet.VirtualMachineProfile?.SecurityProfile?.SecurityType == null
@@ -97,6 +108,7 @@ namespace Microsoft.Azure.Commands.Compute.Automation
                                     specificImageRespone = retrieveSpecificImageFromNotId();
                                     setHyperVGenForImageCheckAndTLDefaulting(specificImageRespone);
                                 }
+
                             }
 
                             string resourceGroupName = this.ResourceGroupName;
@@ -131,6 +143,7 @@ namespace Microsoft.Azure.Commands.Compute.Automation
                                     parameters.VirtualMachineProfile.SecurityProfile.UefiSettings = new UefiSettings(true, true);
                                 }
                             }
+
 
                             // For Cross-tenant RBAC sharing
                             Dictionary<string, List<string>> auxAuthHeader = null;

--- a/src/Compute/Compute/Manual/PSVirtualMachineScaleSet.cs
+++ b/src/Compute/Compute/Manual/PSVirtualMachineScaleSet.cs
@@ -1,4 +1,4 @@
-// 
+ // 
 // Copyright (c) Microsoft and contributors.  All rights reserved.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,3 +28,4 @@ namespace Microsoft.Azure.Commands.Compute.Automation.Models
 
     }
 }
+.None


### PR DESCRIPTION
resolves [Azure/ps-cmdlet-dev-assistant/#30](https://github.com/Azure/ps-cmdlet-dev-assistant/issues/30) 