### PR TITLE
[PSCmdAssistant] added the new query param to retrieve the capacity reservation group resource ids that are owned and shared by a subscription in the List Capacity reservation Group API

### DIFF
--- a/src/Compute/Compute/ChangeLog.md
+++ b/src/Compute/Compute/ChangeLog.md
@@ -20,6 +20,8 @@
 
 -->
 ## Upcoming Release
+* Added new parameter `ResourceIdsOnly` to cmdlet `Get-AzCapacityReservationGroup`.
+* Added parameter `-IdentityType` to cmdlet `Update-AzDiskEncryptionSet`. 
 * Added parameter `-IdentityType` to cmdlet `Update-AzDiskEncryptionSet`. 
 
 ## Version 8.0.0

--- a/src/Compute/Compute/Generated/CapacityReservation/GetAzCapacityReservationGroupCommand.cs
+++ b/src/Compute/Compute/Generated/CapacityReservation/GetAzCapacityReservationGroupCommand.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) Microsoft and contributors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -67,6 +67,12 @@ namespace Microsoft.Azure.Commands.Compute.Automation
             ValueFromPipelineByPropertyName = true,
             HelpMessage = "Get the Instance View of the Capacity Reservation Group.")]
         public SwitchParameter InstanceView { get; set; }
+
+        [Parameter(
+            Mandatory = false,
+            HelpMessage = "Get the Resource Ids only.")]
+        [ValidateSet("CreatedInSubscription", "SharedWithSubscription", "All")]
+        public string ResourceIdsOnly { get; set; }
 
         public override void ExecuteCmdlet()
         {
@@ -148,3 +154,4 @@ namespace Microsoft.Azure.Commands.Compute.Automation
         }
     }
 }
+

--- a/src/Compute/Compute/Generated/Models/PSCapacityReservationGroup.cs
+++ b/src/Compute/Compute/Generated/Models/PSCapacityReservationGroup.cs
@@ -1,4 +1,4 @@
-using System;
+ using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Microsoft.Azure.Management.Compute.Models;
@@ -17,5 +17,6 @@ namespace Microsoft.Azure.Commands.Compute.Automation.Models
         public CapacityReservationGroupInstanceView InstanceView { get; set; }
         public IList<string> Zones { get; set; }
         public ResourceSharingProfile SharingProfile { get; set; }
+        public string ResourceIdsOnly { get; set; }
     }
-}
+}None


### PR DESCRIPTION
resolves [Azure/ps-cmdlet-dev-assistant/28](https://github.com/Azure/ps-cmdlet-dev-assistant/issues/28)