### PR TITLE
[PSCmdAssistant] [Test] Add new param Shield to Set-AzDiskSecurityProfile

### DIFF
--- a/src/Compute/Compute.Test/ScenarioTests/VirtualMachineTests.cs
+++ b/src/Compute/Compute.Test/ScenarioTests/VirtualMachineTests.cs
@@ -675,5 +675,12 @@ namespace Microsoft.Azure.Commands.Compute.Test.ScenarioTests
         {
             TestRunner.RunTestScript("Test-VMSetAzOSCredentialNullRef");
         }
-    }
+
+        [Fact]
+        [Trait(Category.AcceptanceType, Category.CheckIn)]
+        public void testgensetazdisksecurityprofile()
+        {
+            TestRunner.RunTestScript("TestGen-setazdisksecurityprofile");
+        }
+        }
 }

--- a/src/Compute/Compute.Test/ScenarioTests/VirtualMachineTests.ps1
+++ b/src/Compute/Compute.Test/ScenarioTests/VirtualMachineTests.ps1
@@ -7727,3 +7727,55 @@ function Test-VMwithSSHKeyEd25519
         Clean-ResourceGroup $rgname;
     }
 }
+
+function TestGen-setazdisksecurityprofile
+{
+    # Setup
+    $rgname = Get-ComputeTestResourceName;
+    $loc = Get-Location;
+
+    try
+    {
+        New-AzResourceGroup -Name $rgname -Location $loc -Force;
+
+        # VM Profile & Hardware
+        # Create New key vault
+        $kvname = "val" + $rgname;
+        $keyname = "key" + $rgname;
+        $desName= "des" + $rgname;
+
+        # Creating a VM using simple parameterset
+        $securePassword = Get-PasswordForVM | ConvertTo-SecureString -AsPlainText -Force;
+        $user = "admin01";
+        $cred = New-Object System.Management.Automation.PSCredential ($user, $securePassword);
+
+        $securityTypeDSP = "ConfidentialVM_DiskEncryptedWithPlatformKey";
+
+        $diskName = "disk1";
+        $diskconfig = New-AzDiskConfig  -AccountType Premium_LRS -OsType Linux -CreateOption "FromImage" -Location $loc;
+        $diskconfig = Set-AzDiskImageReference -Disk $diskconfig -Id "/Subscriptions/e37510d7-33b6-4676-886f-ee75bcc01871/Providers/Microsoft.Compute/Locations/northeurope/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/windows-cvm/Skus/2019-datacenter-cvm/Versions/latest";
+        $diskconfig = Set-AzDiskSecurityProfile -Disk $diskconfig -SecurityType $securityTypeDSP -Shield "ShieldOn";
+        New-AzDisk -ResourceGroupName $rgname -DiskName $diskName -Disk $diskconfig;
+        $disk = Get-AzDisk -ResourceGroupName $rgname -DiskName $diskName;
+
+        Assert-AreEqual $disk.SecurityProfile.SecurityType $securityTypeDSP;
+        Assert-AreEqual $disk.SecurityProfile.Shield "ShieldOn";
+
+        $securityTypeDSP2 = "ConfidentialVM_VMGuestStateOnlyEncryptedWithPlatformKey";
+        $diskName = "disk2";
+        $diskconfig = New-AzDiskConfig  -AccountType Premium_LRS -OsType Linux -CreateOption "FromImage" -Location $loc;
+        $diskconfig = Set-AzDiskImageReference -Disk $diskconfig -Id "/Subscriptions/e37510d7-33b6-4676-886f-ee75bcc01871/Providers/Microsoft.Compute/Locations/northeurope/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/windows-cvm/Skus/2019-datacenter-cvm/Versions/latest";
+        $diskconfig = Set-AzDiskSecurityProfile -Disk $diskconfig -SecurityType $securityTypeDSP2 -Shield "ShieldDown";
+        New-AzDisk -ResourceGroupName $rgname -DiskName $diskName -Disk $diskconfig;
+        $disk2 = Get-AzDisk -ResourceGroupName $rgname -DiskName $diskName;
+
+        Assert-AreEqual $disk2.SecurityProfile.SecurityType $securityTypeDSP2;
+        Assert-AreEqual $disk2.SecurityProfile.Shield "ShieldDown";
+
+    }
+    finally
+    {
+        # Cleanup
+        Remove-AzResourceGroup -Name $rgname -Force -ErrorAction SilentlyContinue;
+    }
+}

--- a/src/Compute/Compute/ChangeLog.md
+++ b/src/Compute/Compute/ChangeLog.md
@@ -20,6 +20,10 @@
 
 -->
 ## Upcoming Release
+* Added new cmdlet `Set-AzDiskSecurityProfile` with an optional `-Shield` parameter.
+    - The `-Shield` parameter accepts values: `ShieldOn`, `ShieldGone`, `ShieldDown`.
+
+* Upgraded Azure.Core to 1.44.1.
 * Upgraded Azure.Core to 1.44.1.
 
 ## Version 9.0.0

--- a/src/Compute/Compute/Generated/Disk/Config/SetAzDiskSecurityProfile.cs
+++ b/src/Compute/Compute/Generated/Disk/Config/SetAzDiskSecurityProfile.cs
@@ -1,4 +1,4 @@
-﻿// ----------------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------
 //
 // Copyright Microsoft Corporation
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,6 +54,13 @@ namespace Microsoft.Azure.Commands.Compute
            HelpMessage = "ResourceId of the disk encryption set to use for enabling encryption at rest.")]
         public string SecureVMDiskEncryptionSet { get; set; }
 
+        [Parameter(
+           Mandatory = false,
+           ValueFromPipelineByPropertyName = true,
+           HelpMessage = "Gets or sets the Shield property. Possible values include: ShieldOn, ShieldGone, ShieldDown")]
+        [PSArgumentCompleter("ShieldOn", "ShieldGone", "ShieldDown")]
+        public string Shield { get; set; }
+
         protected override void ProcessRecord()
         {
             if (ShouldProcess("DiskSecurityProfile", "Set"))
@@ -92,6 +99,15 @@ namespace Microsoft.Azure.Commands.Compute
                     this.Disk.SecurityProfile = new DiskSecurityProfile();
                 }
                 this.Disk.SecurityProfile.SecureVMDiskEncryptionSetId = this.SecureVMDiskEncryptionSet;
+            }
+
+            if (this.IsParameterBound(c => c.Shield))
+            {
+                if (this.Disk.SecurityProfile == null)
+                {
+                    this.Disk.SecurityProfile = new DiskSecurityProfile();
+                }
+                this.Disk.SecurityProfile.Shield = this.Shield;
             }
 
             WriteObject(this.Disk);

--- a/src/Compute/Compute/Generated/Models/PSDisk.cs
+++ b/src/Compute/Compute/Generated/Models/PSDisk.cs
@@ -79,5 +79,6 @@ namespace Microsoft.Azure.Commands.Compute.Automation.Models
         public string DataAccessAuthMode { get; set; }
         public double? CompletionPercent { get; set; }
         public bool? OptimizedForFrequentAttach { get; set; }
+        public string Shield { get; set; }
     }
 }


### PR DESCRIPTION
resolves [Azure/ps-cmdlet-dev-assistant/47](https://github.com/Azure/ps-cmdlet-dev-assistant/issues/47) <br> 
  This is a Compute SDK AI Assistant Generated PR. This PR is LLM generated so make sure to check for accuracy. 
  Open this PR in github codespaces or your local environment and test the changes. 
  ## Instructions for github codespaces: <br>
  1. Open a new codespace instance on this branch. When codespaces is ready, open a pwsh terminal and run the following commands:<br> 
    a. dotnet build .\src\Compute\Compute.sln 
    b. Import-Module /workspaces/azure-powershell/artifacts/Debug/Az.Accounts/Az.Accounts.psd1; Import-Module /workspaces/azure-powershell/artifacts/Debug/Az.Compute/Az.Compute.psd1
    c. Connect-AzAccount -UseDeviceAuthentication <br>
  ### Once the PR is ready, mark it as Ready For Review and open new Pull Request into Azure/azure-powershell by clicking [here](https://github.com/PSCmdAssistant/azure-powershell/pull/new/cmdassistant-47-12279540653-1)