### PR TITLE
[PSCmdAssistant] [Test] Add a parameter to Set-AzDiskSecurityProfile

### DIFF
--- a/src/Compute/Compute.Test/ScenarioTests/VirtualMachineTests.cs
+++ b/src/Compute/Compute.Test/ScenarioTests/VirtualMachineTests.cs
@@ -675,5 +675,12 @@ namespace Microsoft.Azure.Commands.Compute.Test.ScenarioTests
         {
             TestRunner.RunTestScript("Test-VMSetAzOSCredentialNullRef");
         }
-    }
+
+        [Fact]
+        [Trait(Category.AcceptanceType, Category.CheckIn)]
+        public void testgensetazdisksecurityprofile()
+        {
+            TestRunner.RunTestScript("TestGen-setazdisksecurityprofile");
+        }
+        }
 }

--- a/src/Compute/Compute/ChangeLog.md
+++ b/src/Compute/Compute/ChangeLog.md
@@ -20,6 +20,10 @@
 
 -->
 ## Upcoming Release
+* Added new parameter `-Shield` to `Set-AzDiskSecurityProfile`.
+    - The `-Shield` parameter is a string with allowed values: `ShieldOn`, `ShieldGone`, `ShieldDown`.
+    - This parameter is optional and provides enhanced security profile settings for Azure disks.
+* Upgraded Azure.Core to 1.44.1.
 * Upgraded Azure.Core to 1.44.1.
 
 ## Version 9.0.0

--- a/src/Compute/Compute/Generated/Disk/Config/SetAzDiskSecurityProfile.cs
+++ b/src/Compute/Compute/Generated/Disk/Config/SetAzDiskSecurityProfile.cs
@@ -1,4 +1,4 @@
-﻿// ----------------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------
 //
 // Copyright Microsoft Corporation
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,6 +54,13 @@ namespace Microsoft.Azure.Commands.Compute
            HelpMessage = "ResourceId of the disk encryption set to use for enabling encryption at rest.")]
         public string SecureVMDiskEncryptionSet { get; set; }
 
+        [Parameter(
+           Mandatory = false,
+           ValueFromPipelineByPropertyName = true,
+           HelpMessage = "Set-AzDiskSecurityProfile now has the new parameter Shield which is a string with 3 allowed values: ShieldOn, ShieldGone, ShieldDown")]
+        [PSArgumentCompleter("ShieldOn", "ShieldGone", "ShieldDown")]
+        public string Shield { get; set; }
+
         protected override void ProcessRecord()
         {
             if (ShouldProcess("DiskSecurityProfile", "Set"))
@@ -92,6 +99,15 @@ namespace Microsoft.Azure.Commands.Compute
                     this.Disk.SecurityProfile = new DiskSecurityProfile();
                 }
                 this.Disk.SecurityProfile.SecureVMDiskEncryptionSetId = this.SecureVMDiskEncryptionSet;
+            }
+
+            if (this.IsParameterBound(c => c.Shield))
+            {
+                if (this.Disk.SecurityProfile == null)
+                {
+                    this.Disk.SecurityProfile = new DiskSecurityProfile();
+                }
+                this.Disk.SecurityProfile.Shield = this.Shield;
             }
 
             WriteObject(this.Disk);

--- a/src/Compute/Compute/Generated/Models/PSDisk.cs
+++ b/src/Compute/Compute/Generated/Models/PSDisk.cs
@@ -79,5 +79,6 @@ namespace Microsoft.Azure.Commands.Compute.Automation.Models
         public string DataAccessAuthMode { get; set; }
         public double? CompletionPercent { get; set; }
         public bool? OptimizedForFrequentAttach { get; set; }
+        public string Shield { get; set; }
     }
 }


### PR DESCRIPTION
resolves [Azure/ps-cmdlet-dev-assistant/56](https://github.com/Azure/ps-cmdlet-dev-assistant/issues/56) <br> 
  This is a Compute SDK AI Assistant Generated PR. This PR is LLM generated so make sure to check for accuracy. 
  Open this PR in github codespaces or your local environment and test the changes. 
  ## Instructions for github codespaces: <br>
  1. Open a new codespace instance on this branch. When codespaces is ready, open a pwsh terminal and run the following commands:<br> 
    a. dotnet build .\src\Compute\Compute.sln 
    b. Import-Module /workspaces/azure-powershell/artifacts/Debug/Az.Accounts/Az.Accounts.psd1; Import-Module /workspaces/azure-powershell/artifacts/Debug/Az.Compute/Az.Compute.psd1
    c. Connect-AzAccount -UseDeviceAuthentication <br>
  ### Once the PR is ready, mark it as Ready For Review and open new Pull Request into Azure/azure-powershell by clicking [here](https://github.com/PSCmdAssistant/azure-powershell/pull/new/cmdassistant-56-12280102425-1)