### PR TITLE
[PSCmdAssistant] GalleryImageVersion Powershell commands to support BlockDeletionBeforeEndOfLife parameter.

### DIFF
--- a/src/Compute/Compute/Generated/GalleryImageVersion/GalleryImageVersionCreateOrUpdateMethod.cs
+++ b/src/Compute/Compute/Generated/GalleryImageVersion/GalleryImageVersionCreateOrUpdateMethod.cs
@@ -1,4 +1,4 @@
-//
+ //
 // Copyright (c) Microsoft and contributors.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -410,6 +410,12 @@ namespace Microsoft.Azure.Commands.Compute.Automation
             ValueFromPipelineByPropertyName = true,
             HelpMessage = "The target extended locations where the Image Version is going to be replicated to. This property is updatable.")]
         public Hashtable[] TargetExtendedLocation { get; set; }
+
+        [Parameter(
+            Mandatory = false,
+            ValueFromPipelineByPropertyName = true,
+            HelpMessage = "This boolean will be passed by the customers to enable their GalleryImageVersion resources from accidental deletions. If this boolean is set to true, the image deletions will be blocked before its EndOfLife date.")]
+        public bool BlockDeletionBeforeEndOfLife { get; set; }
     }
 
     [Cmdlet(VerbsData.Update, ResourceManager.Common.AzureRMConstants.AzureRMPrefix + "GalleryImageVersion", DefaultParameterSetName = "DefaultParameter", SupportsShouldProcess = true)]
@@ -714,5 +720,11 @@ namespace Microsoft.Azure.Commands.Compute.Automation
             ValueFromPipelineByPropertyName = true,
             HelpMessage = "Indicates whether or not removing this Gallery Image Version from replicated regions is allowed.")]
         public bool AllowDeletionOfReplicatedLocation { get; set; }
+
+        [Parameter(
+            Mandatory = false,
+            ValueFromPipelineByPropertyName = true,
+            HelpMessage = "This boolean will be passed by the customers to enable their GalleryImageVersion resources from accidental deletions. If this boolean is set to true, the image deletions will be blocked before its EndOfLife date.")]
+        public bool BlockDeletionBeforeEndOfLife { get; set; }
     }
 }

--- a/src/Compute/Compute/Generated/Models/PSGalleryImageVersion.cs
+++ b/src/Compute/Compute/Generated/Models/PSGalleryImageVersion.cs
@@ -49,6 +49,6 @@ namespace Microsoft.Azure.Commands.Compute.Automation.Models
         public string Type { get; set; }
         public string Location { get; set; }
         public IDictionary<string, string> Tags { get; set; }
-
+        public bool? BlockDeletionBeforeEndOfLife { get; set; }
     }
 }


### PR DESCRIPTION
resolves [Azure/azure-powershell-cmdlet-review-pr/1473](https://github.com/Azure/azure-powershell-cmdlet-review-pr/issues/1473) <br> 
  This is a Compute SDK AI Assistant Generated PR. This PR is LLM generated so make sure to check for accuracy. 
  Open this PR in github codespaces or your local environment and test the changes. 
  ## Instructions for github codespaces: <br>
  1. Open a new codespace instance on this branch. When codespaces is ready, open a pwsh terminal and run the following commands:<br> 
    a. dotnet build .\src\Compute\Compute.sln 
    b. Import-Module /workspaces/azure-powershell/artifacts/Debug/Az.Accounts/Az.Accounts.psd1; Import-Module /workspaces/azure-powershell/artifacts/Debug/Az.Compute/Az.Compute.psd1
    c. Connect-AzAccount -UseDeviceAuthentication <br>
  ### Once the PR is ready, mark it as Ready For Review and open new Pull Request into Azure/azure-powershell by clicking [here](https://github.com/PSCmdAssistant/azure-powershell/pull/new/cmdassistant-1473-12658771989-1)